### PR TITLE
Cl post question feature

### DIFF
--- a/core/templates/core/post_detail.html
+++ b/core/templates/core/post_detail.html
@@ -3,8 +3,14 @@
 
 {% block content %}
 <section>
-    <h2><a href="post.url">{{ post.title }}</a></h2>
-    <p>posted by <a href="">{{ post.poster }}</a></p>
+    <h2>
+        {% if post.url %} <!--if the post is a link then have the title link to the url-->
+            <a href="{{ post.url}}">{{ post.title }}</a>
+        {% else %} <!--otherwise, if the post is a question then have the title link to the post-detail page-->
+            <a href="{{ post.get_absolute_url }}">{{ post.title }}</a>
+        {% endif %}
+    </h2>
+    <p>posted by <a href="{% url 'submitter_detail' pk=post.poster_id %}">{{ post.poster }}</a></p>
     <h4>Description:</h4>
     <p>{{post.description}}</p>
     <span>

--- a/core/templates/core/submitter_detail.html
+++ b/core/templates/core/submitter_detail.html
@@ -11,7 +11,12 @@
     {% for post in submitter.post_set.all %}
 
     <li> 
-        <a href="{{ post.url}}"><b>{{ post.title }}</b></a>
+        {% if post.url %} <!--if the post is a link then have the title link to the url-->
+            <a href="{{ post.url}}"><b>{{ post.title }}</b></a>
+        {% else %} <!--otherwise, if the post is a question then have the title link to the post-detail page-->
+            <a href="{{ post.get_absolute_url }}"><b>{{ post.title }}</b></a>
+        {% endif %}
+        
         <p>added {{ post.date_added }}</p>
 
         <ul >

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -14,8 +14,11 @@
         {% for post in posts %} 
         <article class="center mw10 mw10-ns br3 hidden ba b--black-10 mv4">
             <div class="card-header">
-                <a href="{{ post.url}}"><b>{{ post.title }}</b></a>
-                <!--changed from post.get_absolute_url to post.url, b/c we want to see the original article, not the post-detail-->
+                {% if post.url %} <!--if the post is a link then have the title link to the url-->
+                    <a href="{{ post.url}}"><b>{{ post.title }}</b></a>
+                {% else %} <!--otherwise, if the post is a question then have the title link to the post-detail page-->
+                    <a href="{{ post.get_absolute_url }}"><b>{{ post.title }}</b></a>
+                {% endif %}
             </div>
             <div class="card-body p3">
                 <blockquote class="blockquote mb-0">


### PR DESCRIPTION
Updated the index, post detail, and submitter detail pages so that posts that are questions will link to the post detail page instead of an external URL.

Also, corrected the link to the poster name on the post detail page, so that it'll redirect us to the submitter detail page